### PR TITLE
Fix TSOperation compiliation in Xcode 6.

### DIFF
--- a/ThumbnailService/ThumbnailService/Operations/TSOperation.m
+++ b/ThumbnailService/ThumbnailService/Operations/TSOperation.m
@@ -26,6 +26,9 @@
 
 @synthesize completionBlocks = _completionBlocks;
 @synthesize cancelBlocks = _cancelBlocks;
+@synthesize finished = _finished;
+@synthesize executing = _executing;
+@synthesize started = _started;
 
 - (id) init
 {


### PR DESCRIPTION
Fixed by synthesizing the redeclared properties.

This fix improves on #1 because it doesn't introduce new properties.
