### PR TITLE
Cache source identifiers fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.2
 script:
   - fastlane scan -p ThumbnailService/ThumbnailService.xcodeproj --scheme "ThumbnailService"
 

--- a/ThumbnailService/ThumbnailService.xcodeproj/project.pbxproj
+++ b/ThumbnailService/ThumbnailService.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		46C96C3B1FE145C10016C3CB /* NSString+Hash.m in Sources */ = {isa = PBXBuildFile; fileRef = 46C96C391FE145C10016C3CB /* NSString+Hash.m */; };
 		5B1565961815299200C41368 /* ThumbnailService.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FA2677791807AFB900F5B02B /* ThumbnailService.h */; };
 		5B1565971815299700C41368 /* TSSources.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FAF9C73C180EFBBF0091CE94 /* TSSources.h */; };
 		5B1565981815299900C41368 /* TSSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FA2677771807AFB900F5B02B /* TSSource.h */; };
@@ -88,6 +89,8 @@
 /* Begin PBXFileReference section */
 		2DBA118A4B4B32BE247205B5 /* DispatchReleaseMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DispatchReleaseMacro.h; sourceTree = "<group>"; };
 		2DBA1B142ADA6E451CDDB7E1 /* BitmaskMacro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BitmaskMacro.h; sourceTree = "<group>"; };
+		46C96C391FE145C10016C3CB /* NSString+Hash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+Hash.m"; sourceTree = "<group>"; };
+		46C96C3A1FE145C10016C3CB /* NSString+Hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+Hash.h"; sourceTree = "<group>"; };
 		5B5A35501907CBC300241322 /* TSSourceWebView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSSourceWebView.h; sourceTree = "<group>"; };
 		5B5A35511907CBC300241322 /* TSSourceWebView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSSourceWebView.m; sourceTree = "<group>"; };
 		FA26773F1807AF7F00F5B02B /* libThumbnailService.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libThumbnailService.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -340,6 +343,8 @@
 		FAF9C735180EF6DB0091CE94 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				46C96C3A1FE145C10016C3CB /* NSString+Hash.h */,
+				46C96C391FE145C10016C3CB /* NSString+Hash.m */,
 				FAF9C736180EF6DB0091CE94 /* ALAsset+Identifier.h */,
 				FAF9C737180EF6DB0091CE94 /* ALAsset+Identifier.m */,
 				FAF9C738180EF6DB0091CE94 /* UIImageView+ImageFrame.h */,
@@ -392,7 +397,7 @@
 		FA2677371807AF7F00F5B02B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = "Aleksey Garbarev";
 			};
 			buildConfigurationList = FA26773A1807AF7F00F5B02B /* Build configuration list for PBXProject "ThumbnailService" */;
@@ -442,6 +447,7 @@
 				FA6A86E2181195090063C6F9 /* TSSourceVideo.m in Sources */,
 				FA26777D1807AFB900F5B02B /* TSLoadOperation.m in Sources */,
 				FA26777B1807AFB900F5B02B /* TSFileCache.m in Sources */,
+				46C96C3B1FE145C10016C3CB /* NSString+Hash.m in Sources */,
 				FA2677811807AFB900F5B02B /* ThumbnailService.m in Sources */,
 				FA26777C1807AFB900F5B02B /* TSGenerateOperation.m in Sources */,
 				FA2677801807AFB900F5B02B /* TSSource.m in Sources */,
@@ -492,14 +498,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -535,14 +547,20 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -617,7 +635,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
@@ -639,7 +656,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);

--- a/ThumbnailService/ThumbnailService.xcodeproj/xcshareddata/xcschemes/ThumbnailService.xcscheme
+++ b/ThumbnailService/ThumbnailService.xcodeproj/xcshareddata/xcschemes/ThumbnailService.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ThumbnailService/ThumbnailService.xcodeproj/xcshareddata/xcschemes/ThumbnailServiceTests.xcscheme
+++ b/ThumbnailService/ThumbnailService.xcodeproj/xcshareddata/xcschemes/ThumbnailServiceTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -46,6 +47,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ThumbnailService/ThumbnailService/Sources/TSSourceImage.m
+++ b/ThumbnailService/ThumbnailService/Sources/TSSourceImage.m
@@ -7,6 +7,7 @@
 //
 
 #import "TSSourceImage.h"
+#import "NSString+Hash.h"
 
 @implementation TSSourceImage {
     NSURL *_imageURL;
@@ -31,7 +32,7 @@
 - (NSString *)identifier
 {
     if (![super identifier]) {
-        self.identifier = [NSString stringWithFormat:@"%d", (unsigned int)[[_imageURL absoluteString] hash]];
+        self.identifier = [[[_imageURL absoluteString] stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""] md5];
     }
 
     return [super identifier];

--- a/ThumbnailService/ThumbnailService/Sources/TSSourceVideo.m
+++ b/ThumbnailService/ThumbnailService/Sources/TSSourceVideo.m
@@ -8,6 +8,7 @@
 
 #import "TSSourceVideo.h"
 #import "UIImageView+ImageFrame.h"
+#import "NSString+Hash.h"
 
 @implementation TSSourceVideo {
     NSString *identifier;
@@ -28,7 +29,7 @@
     if (self) {
         thumbnailSecond = second;
         videoURL = url;
-        identifier = [NSString stringWithFormat:@"%d-%g", (unsigned int)[[videoURL absoluteString] hash], second];
+        identifier = [NSString stringWithFormat:@"%@-%g", [[[videoURL absoluteString] stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""] md5], second];
     }
     return self;
 }

--- a/ThumbnailService/ThumbnailService/Sources/TSSourceWebView.m
+++ b/ThumbnailService/ThumbnailService/Sources/TSSourceWebView.m
@@ -8,6 +8,7 @@
 
 #import "TSSourceWebView.h"
 #import <UIKit/UIKit.h>
+#import "NSString+Hash.h"
 
 @interface TSSourceWebView ()<UIWebViewDelegate>
 @property (atomic) BOOL loading;
@@ -31,7 +32,7 @@
         webViewLoadingGroup = dispatch_group_create();
         loadingError = nil;
 
-        identifier = [NSString stringWithFormat:@"%d", (unsigned int)[[resourceURL absoluteString] hash]];
+        identifier = [[[resourceURL absoluteString] stringByReplacingOccurrencesOfString:NSHomeDirectory() withString:@""] md5];
     }
     return self;
 }

--- a/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.h
+++ b/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.h
@@ -1,0 +1,17 @@
+//
+//  NSString+Hash.h
+//  Pods
+//
+//  Created by David Martínez Echavarría on 13/12/17.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (Hash)
+
+/**
+ Hashes a given string with the MD5 algorithm.
+ */
+-(NSString *)md5;
+
+@end

--- a/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.h
+++ b/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.h
@@ -12,6 +12,6 @@
 /**
  Hashes a given string with the MD5 algorithm.
  */
--(NSString *)md5;
+@property (nonatomic, readonly) NSString *md5;
 
 @end

--- a/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.m
+++ b/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.m
@@ -1,3 +1,11 @@
+//
+//  NSString+Hash.m
+//  Pods
+//
+//  Created by David Martínez Echavarría on 13/12/17.
+//
+
+#import "NSString+Hash.h"
 #import <CommonCrypto/CommonDigest.h>
 
 @implementation NSString(Hash)

--- a/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.m
+++ b/ThumbnailService/ThumbnailService/Sources/Utils/NSString+Hash.m
@@ -1,0 +1,21 @@
+#import <CommonCrypto/CommonDigest.h>
+
+@implementation NSString(Hash)
+
+-(NSString *)md5 {
+    NSData *data = [self dataUsingEncoding:NSUTF8StringEncoding];
+    uint8_t digest[CC_MD5_DIGEST_LENGTH];
+    
+    CC_MD5(data.bytes, (CC_LONG)data.length, digest);
+    
+    NSMutableString *output = [NSMutableString stringWithCapacity:CC_MD5_DIGEST_LENGTH * 2];
+    
+    for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++)
+    {
+        [output appendFormat:@"%02x", digest[i]];
+    }
+    
+    return output;
+}
+
+@end

--- a/ThumbnailService/ThumbnailServiceTests/RequestTests.m
+++ b/ThumbnailService/ThumbnailServiceTests/RequestTests.m
@@ -191,7 +191,7 @@
     WaitAndCallInBackground(0.8, ^{
         [thumbnailService enqueueRequest:request3 andWait:YES];
         XCTAssert(request1.operation == request3.operation, @"");
-        XCTAssert(request1.operation.queuePriority == NSOperationQueuePriorityNormal, @"%d",request1.operation.queuePriority);
+        XCTAssert(request1.operation.queuePriority == NSOperationQueuePriorityNormal, @"%@", @(request1.operation.queuePriority));
     });
     
     


### PR DESCRIPTION
Use MD5 instead of hash for cache source identifier generation.

Remove NSHomeDirectory from cache source identifier generation.